### PR TITLE
Add alias for system call

### DIFF
--- a/src/FymCore.jl
+++ b/src/FymCore.jl
@@ -24,7 +24,7 @@ export Clock
 
 export update!, close!, reset!, render
 export observe_array, observe_dict, observe_flat
-export systems!, dyn!, step!
+export systems!, dyn!, step!, sys
 export time_over, time
 
 
@@ -300,6 +300,10 @@ end
 
 function state(env::BaseEnv)
     return observe_flat(env)
+end
+
+function sys(env::BaseEnv, name)
+    return env.systems[String(name)]
 end
 
 function _systems(env::BaseEnv)

--- a/src/FymModels.jl
+++ b/src/FymModels.jl
@@ -44,7 +44,7 @@ using Parameters
 include("FymCore.jl")
 @reexport using .FymCore
 
-export FymEnv, set_dot
+export FymEnv
 export FymSystem
 
 # FymSystem list

--- a/src/FymModels.jl
+++ b/src/FymModels.jl
@@ -44,7 +44,7 @@ using Parameters
 include("FymCore.jl")
 @reexport using .FymCore
 
-export FymEnv
+export FymEnv, set_dot
 export FymSystem
 
 # FymSystem list
@@ -52,13 +52,16 @@ export F16LinearLateral, GlidingVehicle3DOF
 
 
 ############ FymEnv ############
-abstract type FymEnv end
-export FymEnv
 # Rule of the type `FymEnv`
 # 1) your custom env should be a subtype of `FymEnv`:
     # CustomEnv <: FymEnv == true
 # 2) your custom env should have a field `env`, whose type is BaseEnv:
     # typeof(CustomEnv.env) == BaseEnv
+abstract type FymEnv end
+
+function sys(fym::FymEnv, name)
+    return fym.env.systems[String(name)]
+end
 
 
 ############ FymSystem ############

--- a/src/FymModels.jl
+++ b/src/FymModels.jl
@@ -44,7 +44,7 @@ using Parameters
 include("FymCore.jl")
 @reexport using .FymCore
 
-export FymEnv
+export FymEnv, sys
 export FymSystem
 
 # FymSystem list
@@ -59,8 +59,8 @@ export F16LinearLateral, GlidingVehicle3DOF
     # typeof(CustomEnv.env) == BaseEnv
 abstract type FymEnv end
 
-function sys(fym::FymEnv, name)
-    return fym.env.systems[String(name)]
+function FymCore.sys(fym::FymEnv, name)
+    return sys(fym.env, name)
 end
 
 

--- a/test/custom_env.jl
+++ b/test/custom_env.jl
@@ -52,7 +52,7 @@ end
 @with_kw mutable struct LinearController
     K = 3*Matrix(I, 3, 3)
 end
-get(ctrl::LinearController, x) = -ctrl.K * x
+Base.get(ctrl::LinearController, x) = -ctrl.K * x
 
 
 end


### PR DESCRIPTION
Add a function `sys` to call a system belonging to a `FymEnv` conveniently.