### PR TITLE
Change data management package from HDF5 to JLD2

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,77 +1,31 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[Adapt]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "42c42f2221906892ceb765dbcb1a51deeffd86d7"
-uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "2.3.0"
+[[Artifacts]]
+deps = ["Pkg"]
+git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.3.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[Blosc]]
-deps = ["Blosc_jll"]
-git-tree-sha1 = "84cf7d0f8fd46ca6f1b3e0305b4b4a37afe50fd6"
-uuid = "a74b3585-a348-5f62-a45c-50e91977d574"
+[[CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.7.0"
-
-[[Blosc_jll]]
-deps = ["Libdl", "Lz4_jll", "Pkg", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "aa9ef39b54a168c3df1b2911e7797e4feee50fbe"
-uuid = "0b7ba130-8d10-5ba8-a3d6-c5182647fed9"
-version = "1.14.3+1"
-
-[[Bzip2_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "03a44490020826950c68005cafb336e5ba08b7e8"
-uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
-version = "1.0.6+4"
-
-[[ColorSchemes]]
-deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random", "StaticArrays"]
-git-tree-sha1 = "5d472aa8908568bc198564db06983913a6c2c8e7"
-uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.10.1"
-
-[[ColorTypes]]
-deps = ["FixedPointNumbers", "Random"]
-git-tree-sha1 = "4bffea7ed1a9f0f3d1a131bbcd4b925548d75288"
-uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.9"
-
-[[Colors]]
-deps = ["ColorTypes", "FixedPointNumbers", "InteractiveUtils", "Reexport"]
-git-tree-sha1 = "008d6bc68dea6beb6303fdc37188cb557391ebf2"
-uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.12.4"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "8cd7b7d1c7f6fcbe7e8743a58adf57788ec7f787"
+git-tree-sha1 = "a706ff10f1cd8dab94f59fd09c0e657db8e77ff0"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.18.0"
-
-[[Contour]]
-deps = ["StaticArrays"]
-git-tree-sha1 = "d05a3a25b762720d40246d5bedf518c9c2614ef5"
-uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
-version = "0.5.5"
-
-[[DataAPI]]
-git-tree-sha1 = "176e23402d80e7743fc26c19c681bfb11246af32"
-uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.3.0"
+version = "3.23.0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "0347f23484a96d56e7096eb1f55c6975be34b11a"
+git-tree-sha1 = "fb0aa371da91c1ff9dc7fbed6122d3e411420b9c"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.6"
-
-[[DataValueInterfaces]]
-git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
-uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
-version = "1.0.0"
+version = "0.18.8"
 
 [[Dates]]
 deps = ["Printf"]
@@ -85,124 +39,24 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
-[[EarCut_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "eabac56550a7d7e0be499125673fbff560eb8b20"
-uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
-version = "2.1.5+0"
-
-[[FFMPEG]]
-deps = ["FFMPEG_jll", "x264_jll"]
-git-tree-sha1 = "9a73ffdc375be61b0e4516d83d880b265366fe1f"
-uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
-version = "0.4.0"
-
-[[FFMPEG_jll]]
-deps = ["Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "LAME_jll", "LibVPX_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "Pkg", "Zlib_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
-git-tree-sha1 = "13a934b9e74a8722bf1786c989de346a9602e695"
-uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
-version = "4.3.1+2"
-
-[[FixedPointNumbers]]
-deps = ["Statistics"]
-git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
-uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-version = "0.8.4"
-
-[[FreeType2_jll]]
-deps = ["Bzip2_jll", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "720eee04e3b496c15e5e2269669c2532fb5005c0"
-uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
-version = "2.10.1+4"
-
-[[FriBidi_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "cfc3485a0a968263c789e314fca5d66daf75ed6c"
-uuid = "559328eb-81f9-559d-9380-de523a88c83c"
-version = "1.0.5+5"
-
-[[GR]]
-deps = ["Base64", "DelimitedFiles", "HTTP", "JSON", "LinearAlgebra", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
-git-tree-sha1 = "cd0f34bd097d4d5eb6bbe01778cf8a7ed35f29d9"
-uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.52.0"
-
-[[GeometryBasics]]
-deps = ["EarCut_jll", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
-git-tree-sha1 = "49d13ebd048bd71315ff98bdc2c560ec16eda2b4"
-uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-version = "0.3.1"
-
-[[GeometryTypes]]
-deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "StaticArrays"]
-git-tree-sha1 = "34bfa994967e893ab2f17b864eec221b3521ba4d"
-uuid = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
-version = "0.8.3"
-
-[[Grisu]]
-git-tree-sha1 = "03d381f65183cb2d0af8b3425fde97263ce9a995"
-uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
-version = "1.0.0"
-
-[[HDF5]]
-deps = ["Blosc", "HDF5_jll", "Libdl", "Mmap", "Random"]
-git-tree-sha1 = "0713cbabdf855852dfab3ce6447c87145f3d9ea8"
-uuid = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
-version = "0.13.6"
-
-[[HDF5_jll]]
-deps = ["Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "3dbc683172cb53428907485a4bb98a29d3874083"
-uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
-version = "1.10.5+6"
-
-[[HTTP]]
-deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
-git-tree-sha1 = "c7ec02c4c6a039a98a15f955462cd7aea5df4508"
-uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.8.19"
-
-[[IniFile]]
-deps = ["Test"]
-git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
-uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
-version = "0.5.0"
-
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[IterTools]]
-git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
-uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-version = "1.3.0"
+[[JLD2]]
+deps = ["CodecZlib", "DataStructures", "MacroTools", "Mmap", "Pkg", "Printf", "Requires", "UUIDs"]
+git-tree-sha1 = "1b8168c14939e43c7c4d2c9e8f0ddd8718965430"
+uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+version = "0.2.4"
 
-[[IteratorInterfaceExtensions]]
-git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
-uuid = "82899510-4779-5014-852e-03e436cf321d"
-version = "1.0.0"
-
-[[JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
-uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
-
-[[LAME_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "a7999edc634307964d5651265ebf7c2e14b4ef91"
-uuid = "c1c5ebd0-6772-5130-a774-d5fcae4a789d"
-version = "3.100.0+2"
+[[JLLWrappers]]
+git-tree-sha1 = "c70593677bbf2c3ccab4f7500d0f4dacfff7b75c"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.1.3"
 
 [[LibGit2]]
 deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
-
-[[LibVPX_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "e02378f5707d0f94af22b99e4aba798e20368f6e"
-uuid = "dd192d2f-8180-539f-9fb4-cc70b1dcf69a"
-version = "1.9.0+0"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -214,69 +68,23 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
-[[Lz4_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "51b1db0732bbdcfabb60e36095cc3ed9c0016932"
-uuid = "5ced341a-0733-55b8-9ab6-a4889d929147"
-version = "1.9.2+2"
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.6"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "426a6978b03a97ceb7ead77775a1da066343ec6e"
-uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.2"
-
-[[MbedTLS_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "c0b1286883cac4e2b617539de41111e0776d02e8"
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.8+0"
-
-[[Measures]]
-git-tree-sha1 = "e498ddeee6f9fdb4551ce855a46f54dbd900245f"
-uuid = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
-version = "0.3.1"
-
-[[Missings]]
-deps = ["DataAPI"]
-git-tree-sha1 = "ed61674a0864832495ffe0a7e889c0da76b0f4c8"
-uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.4"
-
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[NaNMath]]
-git-tree-sha1 = "c84c576296d0e2fbb3fc134d3e09086b3ea617cd"
-uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "0.3.4"
-
-[[Ogg_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "4c3275cda1ba99d1244d0b82a9d0ca871c3cf66b"
-uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
-version = "1.3.4+1"
-
-[[OpenSSL_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "997359379418d233767f926ea0c43f0e731735c0"
-uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "1.1.1+5"
-
-[[Opus_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "cc90a125aa70dbb069adbda2b913b02cf2c5f6fe"
-uuid = "91d4177d-7536-5919-b921-800302f37372"
-version = "1.3.1+2"
-
 [[OrderedCollections]]
-git-tree-sha1 = "16c08bf5dba06609fe45e30860092d6fa41fde7b"
+git-tree-sha1 = "cf59cfed2e2c12e8a2ff0a4f1e9b2cd8650da6db"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.3.1"
+version = "1.3.2"
 
 [[Parameters]]
 deps = ["OrderedCollections", "UnPack"]
@@ -284,33 +92,9 @@ git-tree-sha1 = "38b2e970043613c187bd56a995fe2e551821eb4a"
 uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 version = "0.12.1"
 
-[[Parsers]]
-deps = ["Dates", "Test"]
-git-tree-sha1 = "8077624b3c450b15c087944363606a6ba12f925e"
-uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.10"
-
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-
-[[PlotThemes]]
-deps = ["PlotUtils", "Requires", "Statistics"]
-git-tree-sha1 = "c6f5ea535551b3b16835134697f0c65d06c94b91"
-uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
-version = "2.0.0"
-
-[[PlotUtils]]
-deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
-git-tree-sha1 = "4e098f88dad9a2b518b83124a116be1c49e2b2bf"
-uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.0.7"
-
-[[Plots]]
-deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "GeometryTypes", "JSON", "LinearAlgebra", "Measures", "NaNMath", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
-git-tree-sha1 = "c499e18bbeab024f6de0e0ae285554d153eeb5c5"
-uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.6.8"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -330,17 +114,6 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[RecipesBase]]
-git-tree-sha1 = "6ee6c35fe69e79e17c455a386c1ccdc66d9f7da4"
-uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "1.1.0"
-
-[[RecipesPipeline]]
-deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
-git-tree-sha1 = "4a325c9bcc2d8e62a8f975b9666d0251d53b63b9"
-uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
-version = "0.1.13"
-
 [[Reexport]]
 deps = ["Pkg"]
 git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
@@ -349,9 +122,9 @@ version = "0.2.0"
 
 [[Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "28faf1c963ca1dc3ec87f166d92982e3c4a1f66d"
+git-tree-sha1 = "e05c53ebc86933601d36212a93b39144a2733493"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.1.0"
+version = "1.1.1"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -363,62 +136,26 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 deps = ["Distributed", "Mmap", "Random", "Serialization"]
 uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
-[[Showoff]]
-deps = ["Dates", "Grisu"]
-git-tree-sha1 = "ee010d8f103468309b8afac4abb9be2e18ff1182"
-uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
-version = "0.3.2"
-
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
-[[SortingAlgorithms]]
-deps = ["DataStructures", "Random", "Test"]
-git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
-uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "0.3.1"
 
 [[SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
-[[StaticArrays]]
-deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "016d1e1a00fabc556473b07161da3d39726ded35"
-uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.12.4"
-
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
-[[StatsBase]]
-deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics"]
-git-tree-sha1 = "d72a47c47c522e283db774fc8c459dd5ed773710"
-uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.1"
-
-[[StructArrays]]
-deps = ["Adapt", "DataAPI", "Tables"]
-git-tree-sha1 = "8099ed9fb90b6e754d6ba8c6ed8670f010eadca0"
-uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.4.4"
-
-[[TableTraits]]
-deps = ["IteratorInterfaceExtensions"]
-git-tree-sha1 = "b1ad568ba658d8cbb3b892ed5380a6f3e781a81e"
-uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
-version = "1.0.0"
-
-[[Tables]]
-deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
-git-tree-sha1 = "b7f762e9820b7fab47544c36f26f54ac59cf8abf"
-uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.0.5"
-
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TranscodingStreams]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "7c53c35547de1c5b9d46a4797cf6d8253807108c"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.9.5"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -433,43 +170,7 @@ version = "1.0.2"
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[Zlib_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "fdd89e5ab270ea0f2a0174bd9093e557d06d4bfa"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "320228915c8debb12cb434c59057290f0834dbf6"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+16"
-
-[[Zstd_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "4de91f4313d9e88162d461e282fe3066ab3a3c09"
-uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
-version = "1.4.5+1"
-
-[[libass_jll]]
-deps = ["Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "f02d0db58888592e98c5f4953cef620ce9274eee"
-uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
-version = "0.14.0+3"
-
-[[libfdk_aac_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "e17b4513993b4413d31cffd1b36a63625ebbc3d3"
-uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
-version = "0.1.6+3"
-
-[[libvorbis_jll]]
-deps = ["Libdl", "Ogg_jll", "Pkg"]
-git-tree-sha1 = "8014e1c1033009edcfe820ec25877a9f1862ba4c"
-uuid = "f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
-version = "1.3.6+5"
-
-[[x264_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "e496625b900df1b02ab0e02fad316b77446616ef"
-uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
-version = "2020.7.14+1"
-
-[[x265_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "ac7d44fa1639a780d0ae79ca1a5a7f4181131825"
-uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
-version = "3.0.0+2"
+version = "1.2.11+18"

--- a/Project.toml
+++ b/Project.toml
@@ -1,25 +1,21 @@
 name = "FymEnvs"
 uuid = "d6fd7ba0-2ca9-4676-ba23-5bed9e863cfb"
 authors = ["JinraeKim <kjl950403@gmail.com> and contributors"]
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-HDF5 = "0.13"
 Parameters = "0.12"
-Plots = "1.6"
 ProgressMeter = "1.4"
 Reexport = "0.2"
-StaticArrays = "0.12"
+JLD2 = "0.2"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Result:
 
 ```julia
 # time and progressbar
- 99%|████████████████████████████████████████████████████████████████████████████████████▏|  ETA: 0:00:00  3.513103 seconds (11.45 M allocations: 621.034 MiB, 3.28% gc time)
+ 99%|████████████████████████████████████████████████████████████████████████████████████▎|  ETA: 0:00:00  0.706294 seconds (2.98 M allocations: 1.675 GiB, 11.48% gc time)
 # representation, i.e., show (nested env supported)
 name: test_env
 max_t: 100.0

--- a/src/FymCore.jl
+++ b/src/FymCore.jl
@@ -16,8 +16,6 @@ include("FymLogging.jl")
 using ProgressMeter
 # using Debugger
 
-using StaticArrays
-
 export BaseEnv
 export BaseSystem
 export Clock
@@ -264,8 +262,7 @@ function ode_wrapper(env::BaseEnv)
         end
         env.dyn(env, t; kwargs...)
         res = vcat([dot(system)[:] for system in _systems(env)]...)
-        return SVector{env.state_size[1]}(res)
-        # return res
+        return res
     end
     return wrapper
 end

--- a/src/FymLogging.jl
+++ b/src/FymLogging.jl
@@ -8,10 +8,9 @@ module FymLogging
 
 import FymEnvs: close!, record
 
-# using HDF5
 using JLD2
 using Dates
-using Debugger
+# using Debugger
 
 export Logger, close!, record, load, set_info!
 
@@ -20,7 +19,6 @@ export Logger, close!, record, load, set_info!
 mutable struct Logger
     path
     mode
-    max_len
     info
     buffer
     len
@@ -28,9 +26,8 @@ mutable struct Logger
 end
 
 function init!(logger::Logger;
-                    # path=nothing, log_dir=nothing, file_name="data.h5",
                     path=nothing, log_dir=nothing, file_name="data.jld2",
-                    max_len=10, mode="w")
+                    mode="w")
     if path == nothing
         if log_dir == nothing
             log_dir = joinpath("log", Dates.format(now(), "Ymmd-HMS"))
@@ -39,13 +36,11 @@ function init!(logger::Logger;
         path = joinpath(log_dir, file_name)
     end
     logger.path = path
-    # h5open(logger.path, mode) do dummy  # create .h5
     jldopen(logger.path, mode) do jldfile  # create .jld2
         JLD2.Group(jldfile, "data")  # make group
         JLD2.Group(jldfile, "info")  # make group
     end
     logger.mode = mode
-    logger.max_len = max_len
     logger.info = Dict()
     clear!(logger)
     return logger
@@ -60,17 +55,12 @@ end
 function record(logger::Logger, info::Dict)
     _rec_update!(logger.buffer, info)
     logger.len += 1
-    if logger.len >= logger.max_len
-        flush!(logger)
-    end
 end
 
 function flush!(logger::Logger; info=Dict())
-    # h5open(logger.path, "r+") do h5file
-    jldopen(logger.path, "r+") do h5file
-        _rec_save!(h5file, "/data/", logger.buffer)
-        # @enter _rec_save!(h5file, "/data/", logger.buffer)
-        _info_save!(h5file, info)
+    jldopen(logger.path, "r+") do jldfile
+        _rec_save!(jldfile, "/data/", logger.buffer)
+        _info_save!(jldfile, info)
     end
     clear!(logger)
 end
@@ -87,119 +77,76 @@ end
 
 
 ############ others ############
-function _info_save!(h5file, info::Dict=Dict())
+function _info_save!(jldfile, info::Dict=Dict())
     for (key, val) in info
-        h5file["info"][key] = val
-        # attrs(h5file)[key] = val
+        jldfile["info"][key] = val
     end
 end
 
-"Recursively save the `dic` into the HDF5 file."
-function _rec_save!(h5file, path, dic)
+"Recursively save the `dic` into the JLD2 file."
+function _rec_save!(jldfile, path, dic)
     for (key, val) in dic
         if typeof(val) <: Array
-            # if exists(h5file, path*key)
-            val_tmp = h5file[path*key]
-            val_new = cat(val, val_tmp, dims=1)
-            if haskey(h5file, path*key)
-                @bp
-                h5file[path*key] = cat(h5file[path*key], val, dims=1)
-                # dset = h5file[path*key]
-                # dims = size(dset)
-                # set_dims!(dset, (dims[1]+size(val)[1], dims[2:end]...))
-                # indices_exceptone = [Colon()
-                #                      for _ in 2:length(size(val))]
-                # dset[end-size(val)[1]+1:end, indices_exceptone...] = val
-            else
-                # dset = JLD2.Group(h5file, path * key)
-                # dset = d_create(h5file, path * key, Float64,
-                #              (size(val), (-1, size(val)[2:end]...)),
-                #              "chunk", size(val)
-                #             )
-                # indices_all = [Colon() for _ in 1:length(size(val))]
-                # dset[indices_all...] = val
-                indices_all = [Colon() for _ in 1:length(size(val))]
-                h5file[path * key] = val
-            end
+            jldfile[path * key] = val
         elseif typeof(val) <: Dict
-            _rec_save!(h5file, path * key * "/", val)
+            _rec_save!(jldfile, path * key * "/", val)
         else
             error("Cannot save $(typeof(val)) type")
         end
     end
 end
 
-"Load HDF5 data saved by `Logger`."
+"Load JLD2 data saved by `Logger`."
 function load(path; with_info=false)
-    # h5open(path, "r") do h5file
     data = Dict()
     info = Dict()
-    jldopen(path, "r") do file
-        for key in keys(file["data"])
-            data[key] = file["data"][key]
-        end
-        for key in keys(file["info"])
-            info[key] = file["info"][key]
+    jldopen(path, "r") do jldfile
+        data = _rec_load(jldfile, "data")
+        if with_info
+            info = _rec_load(jldfile, "info")
         end
     end
-
     if with_info
         return data, info
     else
         return data
     end
-    # jldopen(path, "r") do h5file
-    #     data = _rec_load(h5file, "data")
-    #     # data = _rec_load(h5file, "/")
-    #     if with_info
-    #         # info = Dict()
-    #         # attr = attrs(h5file)
-    #         # for name in names(attr)
-    #         #     info[name] = read(attr[name])
-    #         # end
-    #         info = h5file["info"]
-    #         return data, info
-    #     else
-    #         return data
-    #     end
-    # end
 end
 
-function _rec_load(h5file, path)
-    @bp
-    data = read(h5file, path)
-    return data
+function _rec_load(jldfile, path)
+    ans = Dict()
+    for key in keys(jldfile[path])
+        val = jldfile[path * "/" * key]
+        if typeof(val) <: JLD2.Group
+            ans[key] = _rec_load(jldfile, path * "/" * key)
+        else
+            ans[key] = val
+        end
+    end
+    return ans
 end
 
 "Recursively update `base_dict` with `input_dict`."
 function _rec_update!(base_dict, input_dict; is_info=false)
     for (key, val) in input_dict
         if typeof(val) <: Dict
-            _rec_update!(get!(base_dict, key, Dict()), val,
-                         is_info=is_info)
+            _rec_update!(get!(base_dict, key, Dict()), val; is_info=is_info)
         else
             if is_info
                 get!(base_dict, key, val)
             else
                 if !(typeof(val) <: String)
-                    get!(base_dict, key, [])
-                    if length(size(val)) == 0
-                        val = [val]
+                    get!(base_dict, key, Float64[])
+                    if length(size(val)) > 0
+                        val = reshape(val, 1, size(val)...)
                     end
-                    base_dict[key] = cat(base_dict[key],
-                                         reshape(val, 1, size(val)...),
-                                         dims=1)
-                    # append!(get!(base_dict, key, []), val)
+                    base_dict[key] = cat(base_dict[key], val, dims=1)
                 else
                     error("Unsupported data type")
                 end
             end
         end
     end
-end
-
-function raise_unsupported_error()
-    error("Unsupported function yet")
 end
 
 

--- a/test/custom_env.jl
+++ b/test/custom_env.jl
@@ -31,8 +31,16 @@ function init!(fym::TestEnv;
         sys = env.systems["test_sys"]
         x = sys.state
         u = get(fym.controller, x)
-        info = Dict("time" => t, "state" => x, "input" => u)
-
+        info = Dict(
+                    "time" => t,
+                    "state" => x,
+                    "input" => u,
+                    "group" => Dict(
+                                    "time" => t,
+                                    "state" => x,
+                                    "input" => u,
+                                   )
+                   )
         update!(env)
         next_obs = sys.state
         reward = zeros(1)

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,197 @@
+using FymEnvs
+using LinearAlgebra
+
+using Plots
+ENV["GKSwstype"]="nul"  # do not show plot
+# using Debugger
+
+if !isdefined(Main, :TestEnvs)
+    # using Revise; includet("custom_env.jl")  # to avoid conflict
+    include("custom_env.jl")  # to avoid conflict
+    using .TestEnvs
+end
+
+
+function print_msg(test_name)
+    println(">"^6*" "*test_name*" "*"<"^6)
+end
+
+
+function test_Fym()
+    print_msg("FymEnvs")
+    function set_dyn(env, t)
+        # corresponding to `set_dot` of the original fym
+        # you can use any names in this package
+        sys = env.systems["sys"]
+        x = sys.state
+        A = Matrix(I, 3, 3)
+        sys.dot = -A * x
+    end
+    function step(env)
+        t = time(env.clock)
+        sys = env.systems["sys"]
+        x = sys.state
+        update!(env)
+        next_obs = sys.state
+        reward = zeros(1)
+        done = time_over(env.clock)
+        info = Dict(
+                    "time" => t,
+                    "state" => x,
+                   )
+        return next_obs, reward, done, info
+    end
+
+    x0 = collect(1:3)
+    systems = Dict("sys" => BaseSystem(initial_state=x0, name="3d_sys"))
+    log_dir = "data/test"
+    file_name = "fym.h5"
+    logger = Logger(log_dir=log_dir, file_name=file_name)
+    env = BaseEnv(max_t=100.00, logger=logger, name="test_env",)
+    systems!(env, systems)  # set systems; required
+    dyn!(env, set_dyn)  # set dynamics; required
+    step!(env, step)  # set step; required
+
+    reset!(env)  # reset env; required before propagation
+    obs = observe_flat(env)
+    i = 0
+    @time while true
+        render(env)  # not mendatory; would make simulator slow
+        next_obs, reward, done, info = env.step()
+        obs = next_obs
+        i += 1
+        if done
+            break
+        end
+    end
+    close!(env)
+    data = load(env.logger.path)
+    show(env)
+    show(size(data["state"]["sys"]))
+end
+
+function test_largescale_env()
+    print_msg("large-scale envs (nested env)")
+    function set_dyn(env, t, p=0.0)
+        x = env.systems["sys"].state
+        y = env.systems["sys2"].state
+        A = Matrix(I, 25, 25)
+        B = Matrix(I, 25, 25)
+        env.systems["sys"].dot = -p * A * x
+        env.systems["sys2"].dot = -B * y
+        env.systems["env0"].systems["sys"].dot = -p * A * x
+        env.systems["env0"].systems["sys2"].dot = -B * y
+    end
+    function set_dyn0(env, t, p=0.0)  # extend
+        x = env.systems["sys"].state
+        y = env.systems["sys2"].state
+        A = Matrix(I, 25, 25)
+        B = Matrix(I, 25, 25)
+        env.systems["sys"].dot = -p * A * x
+        env.systems["sys2"].dot = -B * y
+    end
+    function step(env, action=nothing)
+        t = time(env.clock)
+        x = env.systems["sys"].state
+        y = env.systems["sys2"].state
+        env0x = env.systems["env0"].systems["sys"].state
+        env0y = env.systems["env0"].systems["sys2"].state
+        update!(env)
+        next_obs = env.systems["sys"].state
+        reward = zeros(1)
+        done = time_over(env.clock)
+        info = Dict("time" => t, "state" => x, "state2" => y,
+                    "env0state" => env0x, "env0state2" => env0y)
+        return next_obs, reward, done, info
+    end
+
+    x0 = collect(1:25)
+    y0 = ones(25)
+    systems0 = Dict(
+                   "sys" => BaseSystem(initial_state=x0),
+                   "sys2" => BaseSystem(initial_state=y0),
+                  )
+    env0 = BaseEnv(systems=systems0, dyn=set_dyn0, name="env0")
+    systems = Dict(
+                   "sys" => BaseSystem(initial_state=x0),
+                   "sys2" => BaseSystem(initial_state=y0),
+                   "env0" => env0,
+                  )
+    log_dir = "data/test"
+    file_name = "largescale.h5"
+    logger = Logger(log_dir=log_dir, file_name=file_name)
+    env = BaseEnv(max_t=10.00, logger=logger, name="env")
+    systems!(env, systems)
+    dyn!(env, set_dyn)
+    step!(env, step)
+    # functions
+    reset!(env)  # reset!
+    # simulation
+    obs = observe_flat(env)
+    i = 0
+    @time while true
+        next_obs, reward, done, info = env.step()
+        obs = next_obs
+        i += 1
+        if done
+            break
+        end
+    end
+    close!(env)
+    data = load(env.logger.path)
+    state = data["state"]["sys"]
+    state2 = data["state"]["sys2"]
+    env0state = data["state"]["env0"]["sys"]
+    env0state2 = data["state"]["env0"]["sys2"]
+    t = data["time"]
+    p = plot(t, state)
+    p2 = plot(t, state2)
+    env0p = plot(t, env0state)
+    env0p2 = plot(t, env0state2)
+    savefig(p, joinpath(log_dir, "state.pdf"))
+    savefig(p2, joinpath(log_dir, "state2.pdf"))
+    savefig(env0p, joinpath(log_dir, "env0state.pdf"))
+    savefig(env0p2, joinpath(log_dir, "env0state2.pdf"))
+    show(env)
+end
+
+function test_custom_env()
+    env = test_env()
+    log_dir = "data/test"
+    file_name = "custom.h5"
+    reset!(env)
+    _sample(env, nothing, log_dir, file_name)
+    data = load(joinpath(log_dir, file_name))
+    for name in ["state", "input"]
+        p = plot(data["time"], data[name])
+        savefig(p, joinpath(log_dir, "custom_"*name*".pdf"))
+    end
+end
+
+function _sample(env::BaseEnv, agent, log_dir, file_name)
+    logger = Logger(log_dir=log_dir, file_name=file_name)
+    obs = observe_flat(env)
+    i = 0
+    @time while true
+        if agent == nothing
+            action = nothing
+        end
+        next_obs, reward, done, info = env.step(action=action)
+        record(logger, info)
+        obs = next_obs
+        i += 1
+        if done
+            break
+        end
+    end
+    close!(env)
+    close!(logger)
+end
+
+function test_all()
+    test_Fym()
+    test_largescale_env()
+    test_custom_env()
+end
+
+test_all()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,58 +16,21 @@ function print_msg(test_name)
     println(">"^6*" "*test_name*" "*"<"^6)
 end
 
+function test_custom_fym()
+    print_msg("custom FymEnv")
+    fym = TestEnv(; max_t=0.1)
 
-function test_Fym()
-    print_msg("FymEnvs")
-    function set_dyn(env, t)
-        # corresponding to `set_dot` of the original fym
-        # you can use any names in this package
-        sys = env.systems["sys"]
-        x = sys.state
-        A = Matrix(I, 3, 3)
-        sys.dot = -A * x
-    end
-    function step(env)
-        t = time(env.clock)
-        sys = env.systems["sys"]
-        x = sys.state
-        update!(env)
-        next_obs = sys.state
-        reward = zeros(1)
-        done = time_over(env.clock)
-        info = Dict(
-                    "time" => t,
-                    "state" => x,
-                   )
-        return next_obs, reward, done, info
-    end
-
-    x0 = collect(1:3)
-    systems = Dict("sys" => BaseSystem(initial_state=x0, name="3d_sys"))
+    env = fym.env
     log_dir = "data/test"
-    file_name = "fym.h5"
-    logger = Logger(log_dir=log_dir, file_name=file_name)
-    env = BaseEnv(max_t=100.00, logger=logger, name="test_env",)
-    systems!(env, systems)  # set systems; required
-    dyn!(env, set_dyn)  # set dynamics; required
-    step!(env, step)  # set step; required
-
-    reset!(env)  # reset env; required before propagation
-    obs = observe_flat(env)
-    i = 0
-    @time while true
-        render(env)  # not mendatory; would make simulator slow
-        next_obs, reward, done, info = env.step()
-        obs = next_obs
-        i += 1
-        if done
-            break
-        end
+    file_name = "custom.h5"
+    reset!(env)
+    _sample(fym, nothing, log_dir, file_name)
+    data, info = load(joinpath(log_dir, file_name),
+                      with_info=true)
+    for name in ["state", "input"]
+        p = plot(data["time"], data[name])
+        savefig(p, joinpath(log_dir, "custom_"*name*".pdf"))
     end
-    close!(env)
-    data = load(env.logger.path)
-    show(env)
-    show(size(data["state"]["sys"]))
 end
 
 function test_reverse_time()
@@ -119,126 +82,13 @@ function test_reverse_time()
     end
     close!(env)
     data = load(env.logger.path)
+
     show(env)
     show(size(data["state"]["sys"]))
 end
 
-function test_largescale_env()
-    print_msg("large-scale envs (nested env)")
-    function set_dyn(env, t, p=0.0)
-        x = env.systems["sys"].state
-        y = env.systems["sys2"].state
-        A = Matrix(I, 25, 25)
-        B = Matrix(I, 25, 25)
-        env.systems["sys"].dot = -p * A * x
-        env.systems["sys2"].dot = -B * y
-        env.systems["env0"].systems["sys"].dot = -p * A * x
-        env.systems["env0"].systems["sys2"].dot = -B * y
-    end
-    function set_dyn0(env, t, p=0.0)  # extend
-        x = env.systems["sys"].state
-        y = env.systems["sys2"].state
-        A = Matrix(I, 25, 25)
-        B = Matrix(I, 25, 25)
-        env.systems["sys"].dot = -p * A * x
-        env.systems["sys2"].dot = -B * y
-    end
-    function step(env, action=nothing)
-        t = time(env.clock)
-        x = env.systems["sys"].state
-        y = env.systems["sys2"].state
-        env0x = env.systems["env0"].systems["sys"].state
-        env0y = env.systems["env0"].systems["sys2"].state
-        update!(env)
-        next_obs = env.systems["sys"].state
-        reward = zeros(1)
-        done = time_over(env.clock)
-        info = Dict("time" => t, "state" => x, "state2" => y,
-                    "env0state" => env0x, "env0state2" => env0y)
-        return next_obs, reward, done, info
-    end
-
-    x0 = collect(1:25)
-    y0 = ones(25)
-    systems0 = Dict(
-                   "sys" => BaseSystem(initial_state=x0),
-                   "sys2" => BaseSystem(initial_state=y0),
-                  )
-    env0 = BaseEnv(systems=systems0, dyn=set_dyn0, name="env0")
-    systems = Dict(
-                   "sys" => BaseSystem(initial_state=x0),
-                   "sys2" => BaseSystem(initial_state=y0),
-                   "env0" => env0,
-                  )
-    log_dir = "data/test"
-    file_name = "largescale.h5"
-    logger = Logger(log_dir=log_dir, file_name=file_name)
-    env = BaseEnv(max_t=10.00, logger=logger, name="env")
-    systems!(env, systems)
-    dyn!(env, set_dyn)
-    step!(env, step)
-    # functions
-    reset!(env)  # reset!
-    # simulation
-    obs = observe_flat(env)
-    i = 0
-    @time while true
-        next_obs, reward, done, info = env.step()
-        obs = next_obs
-        i += 1
-        if done
-            break
-        end
-    end
-    close!(env)
-    data = load(env.logger.path)
-    state = data["state"]["sys"]
-    state2 = data["state"]["sys2"]
-    env0state = data["state"]["env0"]["sys"]
-    env0state2 = data["state"]["env0"]["sys2"]
-    t = data["time"]
-    p = plot(t, state)
-    p2 = plot(t, state2)
-    env0p = plot(t, env0state)
-    env0p2 = plot(t, env0state2)
-    savefig(p, joinpath(log_dir, "state.pdf"))
-    savefig(p2, joinpath(log_dir, "state2.pdf"))
-    savefig(env0p, joinpath(log_dir, "env0state.pdf"))
-    savefig(env0p2, joinpath(log_dir, "env0state2.pdf"))
-    show(env)
-end
-
-function test_custom_env()
-    env = test_env()
-    log_dir = "data/test"
-    file_name = "custom.h5"
-    reset!(env)
-    _sample(env, nothing, log_dir, file_name)
-    data = load(joinpath(log_dir, file_name))
-    for name in ["state", "input"]
-        p = plot(data["time"], data[name])
-        savefig(p, joinpath(log_dir, "custom_"*name*".pdf"))
-    end
-end
-
-function test_custom_fym()
-    fym = TestEnv()
-
-    env = fym.env
-    log_dir = "data/test"
-    file_name = "custom.h5"
-    reset!(env)
-    _sample(fym, nothing, log_dir, file_name)
-    data, info = load(joinpath(log_dir, file_name),
-                      with_info=true)
-    for name in ["state", "input"]
-        p = plot(data["time"], data[name])
-        savefig(p, joinpath(log_dir, "custom_"*name*".pdf"))
-    end
-end
-
 function _sample(env::BaseEnv, agent, log_dir, file_name)
-    logger = Logger(log_dir=log_dir, file_name=file_name, max_len=1000)
+    logger = Logger(log_dir=log_dir, file_name=file_name)
     obs = observe_flat(env)
     i = 0
     @time while true
@@ -259,7 +109,7 @@ end
 
 function _sample(fym::FymEnv, agent, log_dir, file_name)
     env = fym.env
-    logger = Logger(log_dir=log_dir, file_name=file_name, max_len=1000)
+    logger = Logger(log_dir=log_dir, file_name=file_name)
     obs = observe_flat(env)
     i = 0
     @time while true
@@ -286,14 +136,8 @@ function _sample(fym::FymEnv, agent, log_dir, file_name)
 end
 
 function test_all()
-    # test_Fym()
-    # test_reverse_time()
-    # test_largescale_env()
     test_custom_fym()
-end
-
-function test_deprecated()
-    test_custom_env()
+    test_reverse_time()
 end
 
 test_all()

--- a/test/set_info_dict_issue.jl
+++ b/test/set_info_dict_issue.jl
@@ -2,38 +2,33 @@ using FymEnvs
 using LinearAlgebra
 
 if !isdefined(Main, :TestEnvs)
-    # using Revise; includet("custom_env.jl")  # to avoid conflict
     include("custom_env.jl")  # to avoid conflict
     using .TestEnvs
 end
 
 
-function print_msg(test_name)
-    println(">"^6*" "*test_name*" "*"<"^6)
-end
-
-
 function test_custom_fym()
-    fym = TestEnv()
+    fym = TestEnv(; max_t=0.1)
 
     env = fym.env
     log_dir = "data/test"
     file_name = "custom.jld2"
-    # file_name = "custom.h5"
     reset!(env)
     _sample(fym, nothing, log_dir, file_name)
     data, info = load(joinpath(log_dir, file_name),
                       with_info=true)
-    @bp
+    print(info)
+
+    reset!(env)
     _sample2(fym, nothing, log_dir, file_name)
     data, info = load(joinpath(log_dir, file_name),
                       with_info=true)
-    @bp
+    print(info)
 end
 
 function _sample(fym::FymEnv, agent, log_dir, file_name)
     env = fym.env
-    logger = Logger(log_dir=log_dir, file_name=file_name, max_len=10)
+    logger = Logger(log_dir=log_dir, file_name=file_name)
     obs = observe_flat(env)
     i = 0
     @time while true
@@ -61,7 +56,7 @@ end
 
 function _sample2(fym::FymEnv, agent, log_dir, file_name)
     env = fym.env
-    logger = Logger(log_dir=log_dir, file_name=file_name, max_len=1000)
+    logger = Logger(log_dir=log_dir, file_name=file_name)
     obs = observe_flat(env)
     i = 0
     @time while true
@@ -87,5 +82,4 @@ function _sample2(fym::FymEnv, agent, log_dir, file_name)
     close!(logger)
 end
 
-# @enter test_custom_fym()
 test_custom_fym()

--- a/test/set_info_dict_issue.jl
+++ b/test/set_info_dict_issue.jl
@@ -1,0 +1,87 @@
+using FymEnvs
+using LinearAlgebra
+
+if !isdefined(Main, :TestEnvs)
+    # using Revise; includet("custom_env.jl")  # to avoid conflict
+    include("custom_env.jl")  # to avoid conflict
+    using .TestEnvs
+end
+
+
+function print_msg(test_name)
+    println(">"^6*" "*test_name*" "*"<"^6)
+end
+
+
+function test_custom_fym()
+    fym = TestEnv()
+
+    env = fym.env
+    log_dir = "data/test"
+    file_name = "custom.h5"
+    reset!(env)
+    _sample(fym, nothing, log_dir, file_name)
+    data, info = load(joinpath(log_dir, file_name),
+                      with_info=true)
+    _sample2(fym, nothing, log_dir, file_name)
+    data, info = load(joinpath(log_dir, file_name),
+                      with_info=true)
+end
+
+function _sample(fym::FymEnv, agent, log_dir, file_name)
+    env = fym.env
+    logger = Logger(log_dir=log_dir, file_name=file_name, max_len=1000)
+    obs = observe_flat(env)
+    i = 0
+    @time while true
+        if agent == nothing
+            action = nothing
+            if time(env.clock) > 0.5
+                fym.controller.K = - 3*Matrix(I, 3, 3)
+            end
+        end
+        next_obs, reward, done, info = env.step(action=action)
+        record(logger, info)
+        obs = next_obs
+        i += 1
+        if done
+            config = Dict(
+                          "name" => env.name,
+                       )
+            set_info!(logger, config)
+            break
+        end
+    end
+    close!(env)
+    close!(logger)
+end
+
+function _sample2(fym::FymEnv, agent, log_dir, file_name)
+    env = fym.env
+    logger = Logger(log_dir=log_dir, file_name=file_name, max_len=1000)
+    obs = observe_flat(env)
+    i = 0
+    @time while true
+        if agent == nothing
+            action = nothing
+            if time(env.clock) > 0.5
+                fym.controller.K = - 3*Matrix(I, 3, 3)
+            end
+        end
+        next_obs, reward, done, info = env.step(action=action)
+        record(logger, info)
+        obs = next_obs
+        i += 1
+        if done
+            config = Dict(
+                          "name" => Dict(),
+                       )
+            set_info!(logger, config)
+            break
+        end
+    end
+    close!(env)
+    close!(logger)
+end
+
+test_custom_fym()

--- a/test/set_info_dict_issue.jl
+++ b/test/set_info_dict_issue.jl
@@ -18,19 +18,22 @@ function test_custom_fym()
 
     env = fym.env
     log_dir = "data/test"
-    file_name = "custom.h5"
+    file_name = "custom.jld2"
+    # file_name = "custom.h5"
     reset!(env)
     _sample(fym, nothing, log_dir, file_name)
     data, info = load(joinpath(log_dir, file_name),
                       with_info=true)
+    @bp
     _sample2(fym, nothing, log_dir, file_name)
     data, info = load(joinpath(log_dir, file_name),
                       with_info=true)
+    @bp
 end
 
 function _sample(fym::FymEnv, agent, log_dir, file_name)
     env = fym.env
-    logger = Logger(log_dir=log_dir, file_name=file_name, max_len=1000)
+    logger = Logger(log_dir=log_dir, file_name=file_name, max_len=10)
     obs = observe_flat(env)
     i = 0
     @time while true
@@ -84,4 +87,5 @@ function _sample2(fym::FymEnv, agent, log_dir, file_name)
     close!(logger)
 end
 
+# @enter test_custom_fym()
 test_custom_fym()


### PR DESCRIPTION
# Summary
## Data management package
- [HDF5](https://github.com/JuliaIO/HDF5.jl) had been used for data management.
However, due to difficulty of saving arbitrary data type (related issue raised in #12), the data management package is changed to [JLD2](https://github.com/JuliaIO/JLD2.jl).
    - Advantage: can easily save more flexible data, e.g., dict-in-dict type data.
    - Drawback: due to the lack of support in **JLD2.jl**, periodic recording trajectory data is no longer supported in this package. Fortunately, as a user, it has not appeared that a simulation requires such functionality for memory management.

## Dependencies and Compatibility
- Old and unused deps. and compat. are discarded.


# Note
- `Logger` no longer receives argument `max_len`.