### PR TITLE
Fix a bug of time_over

### DIFF
--- a/src/FymCore.jl
+++ b/src/FymCore.jl
@@ -75,17 +75,15 @@ end
 "Check if the time is larger than max_t."
 function time_over(clock::Clock; t=nothing)
     if t == nothing
-        return sign(clock.dt) * (time(clock) - clock.max_t) >= 0.0
-    else
-        return sign(clock.dt) * (t - clock.max_t) >= 0.0
+        t = time(clock)
     end
+    return sign(clock.dt) * (t - clock.max_t) > 0.5 * abs(clock.dt)
 end
 
 function thist(clock::Clock)
     thist = clock.thist .+ time(clock)
     if time_over(clock, t=thist[end])
-        index = findfirst(sign(clock.dt)*(thist .- clock.max_t) .> 0.0)
-        # index = findfirst(thist .> clock.max_t)
+        index = findfirst(sign(clock.dt)*(thist .- clock.max_t) .> 0.5 * abs(clock.dt))
         if index == nothing
             return thist
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ end
 
 function test_custom_fym()
     print_msg("custom FymEnv")
-    fym = TestEnv(; max_t=0.1)
+    fym = TestEnv(; dt=0.001, max_t=0.1)
 
     env = fym.env
     log_dir = "data/test"


### PR DESCRIPTION
## Explanation
`time_over` method for `Clock` is important to indicate if the simulation is over.

In the previous version, it sometimes terminates simulation before when supposed to be stopped by numerical precision error.

There's no difference of usage, but `time_over` method becomes more appropriate to indicate the termination of simulation.

## Note
Roughly speaking, `time_over` determines whether the simulation is terminated by checking "the current time (after `update!`) is larger than `0.5 * dt` for the case of forward integration. It is similar to the case of backward integration.